### PR TITLE
Only update options.type if it doesn't already exist

### DIFF
--- a/addon/components/mapbox-gl-source.js
+++ b/addon/components/mapbox-gl-source.js
@@ -35,7 +35,7 @@ export default Component.extend({
     const { sourceId, dataType, data } = getProperties(this, 'sourceId', 'dataType', 'data');
     let options = get(this, 'options') || {};
 
-    if (dataType) {
+    if (!options.type) {
       options.type = dataType;
     }
 


### PR DESCRIPTION
When implementing a `source`, I attempted to pass in a complete `options` object, including `type`.  

The current code:
```
    if (dataType) {
      options.type = dataType;
    }
```
will always replace `options.type` with 'geojson', because `dataType:geojson` is always set.

This PR only updates `options.type` if it doesn't already exist.  Basically, it checks for `options.type` first, then overrides it with `dataType`... if `dataType` was not set explicitly, it uses the default 'geojson'