### PR TITLE
Schedule gl-call’s “sendAction” in afterRender

### DIFF
--- a/addon/components/mapbox-gl-call.js
+++ b/addon/components/mapbox-gl-call.js
@@ -4,7 +4,7 @@ const {
   assert,
   Component,
   getProperties,
-  run: { schedule }
+  run: { scheduleOnce }
 } = Ember;
 
 const MapboxGlCallComponent = Component.extend({
@@ -32,7 +32,7 @@ const MapboxGlCallComponent = Component.extend({
     assert('mapbox-gl-call func is required and must be a string', typeof func === 'string');
     assert(`mapbox-gl-call ${func} must be a function on ${obj}`, typeof obj[func] === 'function');
 
-    schedule('afterRender', () => {
+    scheduleOnce('afterRender', () => {
       this.sendAction('onResp', obj[func].apply(obj, args));
     });
   }

--- a/addon/components/mapbox-gl-call.js
+++ b/addon/components/mapbox-gl-call.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 const {
   assert,
   Component,
-  getProperties
+  getProperties,
+  run: { schedule }
 } = Ember;
 
 const MapboxGlCallComponent = Component.extend({
@@ -31,7 +32,9 @@ const MapboxGlCallComponent = Component.extend({
     assert('mapbox-gl-call func is required and must be a string', typeof func === 'string');
     assert(`mapbox-gl-call ${func} must be a function on ${obj}`, typeof obj[func] === 'function');
 
-    this.sendAction('onResp', obj[func].apply(obj, args));
+    schedule('afterRender', () => {
+      this.sendAction('onResp', obj[func].apply(obj, args));
+    });
   }
 });
 


### PR DESCRIPTION
This PR schedules mapbox-gl-call’s sendAction method call inside an `afterRender` runLoop callback to ensure that any DOM-sensitive Map methods have correct context before running.

Here's what I was seeing:
In the context of a route transition, [map.resize()](https://www.mapbox.com/mapbox-gl-js/api/#map#resize) was being called before a route transition finished (and actually affected the DOM) and after a fitBounds animation started, meaning it never had the correct DOM context to resize properly. Two things had to happen:

 - ember-mapbox-gl’s call needed to be wrapped in an afterRender callback in the Run loop so that things were synchronous
 - resize() must be called before fitBounds, but after a render has completed

With this PR, all Map methods wait for rendering to complete before running. For example, if I use `{{map.call 'resize'}}`, ember-mapbox-gl will wait for Ember's `afterRender` hook to fire before attempting to resize based on context.

Perhaps there is a different way to do this - maybe Map methods are selectively wrapped in afterRender depending on whether they are DOM-sensitive. 

Additionally, I wasn't sure how to test for this, but all current tests are passing.

Thanks!