### PR TITLE
Update mapbox-gl-popup.hbs

### DIFF
--- a/addon/templates/components/mapbox-gl-popup.hbs
+++ b/addon/templates/components/mapbox-gl-popup.hbs
@@ -1,3 +1,3 @@
 {{#ember-wormhole destinationElement=domContent}}
-  {{yield}}
+  {{yield (hash on=(component 'mapbox-gl-on' eventSource=this.popup))}}
 {{/ember-wormhole}}

--- a/tests/integration/components/mapbox-gl-popup-test.js
+++ b/tests/integration/components/mapbox-gl-popup-test.js
@@ -1,5 +1,6 @@
 import { Map } from 'mapbox-gl';
 import { moduleForComponent, test } from 'ember-qunit';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('mapbox-gl-popup', 'Integration | Component | mapbox gl popup', {
@@ -18,4 +19,34 @@ test('it renders', function(assert) {
   assert.expect(0);
 
   this.render(hbs`{{mapbox-gl-popup map=map}}`);
+});
+
+test('it bubbles events from yielded component mapbox-gl-on', function(assert) {
+  assert.expect(3);
+  const done = assert.async();
+
+  const event = {};
+
+  this.set('eventSource', {
+    on(eventName, cb) {
+      assert.equal(eventName, 'close', 'subscribes to lowercased event name');
+
+      run.next(cb, event);
+    },
+
+    off(eventName) {
+      assert.equal(eventName, 'close', 'unsubscribes to lowercased event name');
+    }
+  });
+
+  this.on('onEvent', (ev) => {
+    assert.equal(ev, event, 'sends event to the action');
+    done();
+  });
+
+  this.render(hbs`
+    {{#mapbox-gl-popup map=map as |popup|}}
+      {{popup.on 'close' (action 'onEvent') eventSource=eventSource}}
+    {{/mapbox-gl-popup}}
+  `);
 });


### PR DESCRIPTION
Closes #48 by yielding the mapbox-gl-on component with the current popup context. 