### PR TITLE
59 access token optional

### DIFF
--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -20,8 +20,8 @@ export default Component.extend({
     this.map = null;
     this.glSupported = MapboxGl.supported();
 
-    const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'];
-    warn('mapbox-gl config is required in config/environment', mbglConfig);
+    const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'] || {};
+    warn('mapbox-gl config is missing in config/environment', mbglConfig);
     warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string');
 
     MapboxGl.accessToken = mbglConfig.accessToken;

--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -22,7 +22,7 @@ export default Component.extend({
 
     const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'] || {};
     warn('mapbox-gl config is missing in config/environment', mbglConfig, { id: 'ember-mapbox-gl.config-object' });
-    warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string', { id: 'ember-mapbox-gl.config-object' });
+    warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string', { id: 'ember-mapbox-gl.access-token' });
 
     MapboxGl.accessToken = mbglConfig.accessToken;
   },

--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -21,8 +21,8 @@ export default Component.extend({
     this.glSupported = MapboxGl.supported();
 
     const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'] || {};
-    warn('mapbox-gl config is missing in config/environment', mbglConfig);
-    warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string');
+    warn('mapbox-gl config is missing in config/environment', mbglConfig, { id: 'ember-mapbox-gl.config-object' });
+    warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string', { id: 'ember-mapbox-gl.config-object' });
 
     MapboxGl.accessToken = mbglConfig.accessToken;
   },

--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { assign } from '@ember/polyfills';
 import { get, set } from '@ember/object';
 import { getOwner } from '@ember/application';
@@ -22,7 +22,7 @@ export default Component.extend({
 
     const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'];
     assert('mapbox-gl config is required in config/environment', mbglConfig);
-    assert('mapbox-gl config must have an accessToken string', typeof mbglConfig.accessToken === 'string');
+    warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string');
 
     MapboxGl.accessToken = mbglConfig.accessToken;
   },

--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -1,4 +1,4 @@
-import { assert, warn } from '@ember/debug';
+import { warn } from '@ember/debug';
 import { assign } from '@ember/polyfills';
 import { get, set } from '@ember/object';
 import { getOwner } from '@ember/application';
@@ -21,7 +21,7 @@ export default Component.extend({
     this.glSupported = MapboxGl.supported();
 
     const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'];
-    assert('mapbox-gl config is required in config/environment', mbglConfig);
+    warn('mapbox-gl config is required in config/environment', mbglConfig);
     warn('mapbox-gl config is missing an accessToken string', typeof mbglConfig.accessToken === 'string');
 
     MapboxGl.accessToken = mbglConfig.accessToken;


### PR DESCRIPTION
This pull request makes the configuration object and the MapboxGL accessToken optional. Instead of `assert`, it uses `warn`, which is stripped away in production builds. 

Closes #59 