### PR TITLE
Default objects for environment.js

### DIFF
--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -45,8 +45,8 @@ export default Component.extend({
   },
 
   _setup() {
-    const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'] || {};
-    const options = assign({}, mbglConfig.map, get(this, 'initOptions'));
+    const mbglConfig = get(getOwner(this).resolveRegistration('config:environment'), 'mapbox-gl.map');
+    const options = assign({}, mbglConfig, get(this, 'initOptions'));
     options.container = this.element;
 
     const map = new MapboxGl.Map(options);

--- a/addon/components/mapbox-gl.js
+++ b/addon/components/mapbox-gl.js
@@ -45,7 +45,7 @@ export default Component.extend({
   },
 
   _setup() {
-    const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'];
+    const mbglConfig = getOwner(this).resolveRegistration('config:environment')['mapbox-gl'] || {};
     const options = assign({}, mbglConfig.map, get(this, 'initOptions'));
     options.container = this.element;
 


### PR DESCRIPTION
I found a few more issues downstream of removing the `mapbox-gl` config object. There is also a `map` property that the addon looks for. Thoughts? 