### PR TITLE
Fix dummy site

### DIFF
--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,5 @@
 {{#mapbox-gl as |map|}}
-  {{#map.source options=(hash data=wanderDrone) as |source|}}
+  {{#map.source options=(hash data=wanderDrone type='geojson') as |source|}}
     {{source.layer layer=(hash type='symbol' layout=(hash icon-image='rocket-15'))}}
   {{/map.source}}
 


### PR DESCRIPTION
Somehow the dummy app broke. This fixes it by providing the type property for the source.