### PR TITLE
Move mapbox-gl to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ember-auto-import": "^1.2.13",
     "ember-cli-babel": "^6.16.0",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-wormhole": "^0.5.1"
+    "ember-wormhole": "^0.5.1",
+    "mapbox-gl": "^0.49.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
@@ -59,7 +60,6 @@
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.7.0",
-    "mapbox-gl": "^0.49.0",
     "qunit-dom": "^0.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR moves mapbox-gl from devDependencies to dependencies. This follows from [instructions](https://github.com/ef4/ember-auto-import#usage-from-addons) for ember-auto-import, which asks that dependencies it imports from within an addon be added to `dependencies`. 

Currently, I have an addon that uses `ember-mapbox-gl`, and must use ember-auto-import to include some `@turf` dependencies. However, `ember-mapbox-gl` lists `mapbox-gl` in its devDependencies, which throws the following error:

> ember-mapbox-gl tried to import "mapbox-gl" from addon code, but "mapbox-gl" is a devDependency. You may need to move it into dependencies.

After making this change on a local version of ember-mapbox-gl, I'm able to get around my import problem.

What do we lose by making this change? I am not sure I understand enough about how package versions are resolved. I assume this has something to do with allowing addon consumers specific their own mapbox-gl version. Thoughts? 



