### PR TITLE
add build time optional lazy loading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'module'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
       env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-default-lazy
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=ember-default-mapbox-gl-0.46
     - env: EMBER_TRY_SCENARIO=ember-default-mapbox-gl-0.47

--- a/addon/-private/mapbox-loader-dynamic.js
+++ b/addon/-private/mapbox-loader-dynamic.js
@@ -1,0 +1,25 @@
+import { resolve } from 'rsvp';
+import EmberObject, { setProperties } from '@ember/object';
+
+export default EmberObject.create({
+  isLoaded: false,
+  Mapbox: null,
+
+  load(config = {}) {
+    if (this.isLoaded) {
+      return resolve();
+    }
+
+    return import('mapbox-gl')
+      .then((module) => {
+        if ('accessToken' in  config) {
+          module.default.accessToken = config.accessToken;
+        }
+
+        setProperties(this, {
+          Mapbox: module.default,
+          isLoaded: true
+        });
+      });
+  }
+});

--- a/addon/-private/mapbox-loader-static.js
+++ b/addon/-private/mapbox-loader-static.js
@@ -1,0 +1,23 @@
+import { resolve } from 'rsvp';
+import EmberObject, { setProperties } from '@ember/object';
+import Mapbox from 'mapbox-gl';
+
+export default EmberObject.create({
+  isLoaded: false,
+  Mapbox: null,
+
+  load(config = {}) {
+    if (!this.isLoaded) {
+      if ('accessToken' in  config) {
+        Mapbox.accessToken = config.accessToken;
+      }
+
+      setProperties(this, {
+        Mapbox: Mapbox,
+        isLoaded: true
+      });
+    }
+
+    return resolve();
+  }
+})

--- a/addon/components/mapbox-gl-marker.js
+++ b/addon/components/mapbox-gl-marker.js
@@ -5,7 +5,7 @@ import { getProperties, get, set } from '@ember/object';
 import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import layout from '../templates/components/mapbox-gl-marker';
-import MapboxGl from 'mapbox-gl';
+import MapboxLoader from 'ember-mapbox-gl/-private/mapbox-loader';
 
 /**
  * A utility that brokers HTTP requests...
@@ -59,7 +59,7 @@ export default Component.extend({
       get(getOwner(this).resolveRegistration('config:environment'), 'mapbox-gl.marker'),
       initOptions);
 
-    const marker = new MapboxGl.Marker(this.element, options)
+    const marker = new MapboxLoader.Mapbox.Marker(this.element, options)
       .setLngLat(lngLat)
       .addTo(this.map);
 

--- a/addon/components/mapbox-gl-popup.js
+++ b/addon/components/mapbox-gl-popup.js
@@ -4,7 +4,7 @@ import { getProperties, get } from '@ember/object';
 import { bind } from '@ember/runloop';
 import Component from '@ember/component';
 import layout from '../templates/components/mapbox-gl-popup';
-import MapboxGl from 'mapbox-gl';
+import MapboxLoader from 'ember-mapbox-gl/-private/mapbox-loader';
 
 /**
   Adds a [popup](https://www.mapbox.com/mapbox-gl-js/api/#popup) to the map.
@@ -65,7 +65,7 @@ export default Component.extend({
       get(getOwner(this).resolveRegistration('config:environment'), 'mapbox-gl.popup'),
       initOptions);
 
-    this.popup = new MapboxGl.Popup(options)
+    this.popup = new MapboxLoader.Mapbox.Popup(options)
       .setDOMContent(this.domContent)
       .on('close', this._onClose);
 

--- a/addon/templates/components/mapbox-gl.hbs
+++ b/addon/templates/components/mapbox-gl.hbs
@@ -1,18 +1,22 @@
-{{#if glSupported}}
-  {{#if map}}
-    {{yield
-      (hash
-        call=(component 'mapbox-gl-call' obj=map)
-        control=(component 'mapbox-gl-control' map=map)
-        image=(component 'mapbox-gl-image' map=map)
-        layer=(component 'mapbox-gl-layer' map=map)
-        marker=(component 'mapbox-gl-marker' map=map)
-        on=(component 'mapbox-gl-on' eventSource=map)
-        popup=(component 'mapbox-gl-popup' map=map)
-        source=(component 'mapbox-gl-source' map=map)
-      )
-    }}
+{{#if _loader.isLoaded}}
+  {{#if _glSupported}}
+    {{#if _map}}
+      {{#if _isMapLoaded}}
+        {{yield
+          (hash
+            call=(component 'mapbox-gl-call' obj=_map)
+            control=(component 'mapbox-gl-control' map=_map)
+            image=(component 'mapbox-gl-image' map=_map)
+            layer=(component 'mapbox-gl-layer' map=_map)
+            marker=(component 'mapbox-gl-marker' map=_map)
+            on=(component 'mapbox-gl-on' eventSource=_map)
+            popup=(component 'mapbox-gl-popup' map=_map)
+            source=(component 'mapbox-gl-source' map=_map)
+          )
+        }}
+      {{/if}}
+    {{/if}}
+  {{else}}
+    {{yield to='inverse'}}
   {{/if}}
-{{else}}
-  {{yield to='inverse'}}
 {{/if}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -58,6 +58,15 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-default-lazy',
+          env: {
+            LAZY_LOAD: 'true'
+          },
+          npm: {
+            devDependencies: {}
+          }
+        },
+        {
           name: 'ember-default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // vendorFiles: { 'jquery.js': null }
+    [require('./package').name]: {
+      lazyLoad: process.env.LAZY_LOAD === 'true'
+    }
   });
 
   return app.toTree();

--- a/index.js
+++ b/index.js
@@ -3,6 +3,46 @@
 module.exports = {
   name: require('./package').name,
 
+  options: {
+    babel: {
+      plugins: [
+        // Ensure that `ember-auto-import` can handle the dynamic imports
+        require('ember-auto-import/babel-plugin')
+      ]
+    }
+  },
+
+  addonJsFiles() {
+    const Funnel = require('broccoli-funnel');
+    const config = this._findHost().options[this.name];
+
+    const tree = this._super.addonJsFiles.apply(this, arguments);
+
+    if (config && config.lazyLoad === true) {
+      return new Funnel(tree, {
+        exclude: [ 'ember-mapbox-gl/-private/mapbox-loader-static.js' ],
+        getDestinationPath(relativePath) {
+          if (relativePath === 'ember-mapbox-gl/-private/mapbox-loader-dynamic.js') {
+            return 'ember-mapbox-gl/-private/mapbox-loader.js';
+          }
+
+          return relativePath;
+        }
+      });
+    }
+
+    return new Funnel(tree, {
+      exclude: [ 'ember-mapbox-gl/-private/mapbox-loader-dynamic.js' ],
+      getDestinationPath(relativePath) {
+        if (relativePath === 'ember-mapbox-gl/-private/mapbox-loader-static.js') {
+          return 'ember-mapbox-gl/-private/mapbox-loader.js';
+        }
+
+        return relativePath;
+      }
+    });
+  },
+
   treeForStyles(tree) {
     const Funnel = require('broccoli-funnel');
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.1",
     "ember-cli": "~3.5.1",
     "ember-cli-addon-docs": "^0.6.0",
     "ember-cli-addon-docs-yuidoc": "0.2.1",
@@ -48,8 +49,8 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.1.2",
     "ember-native-dom-event-dispatcher": "^0.6.0",
+    "ember-qunit": "^4.1.2",
     "ember-qunit-assert-helpers": "^0.2.0",
     "ember-resolver": "^5.0.1",
     "ember-sinon": "^3.0.0",

--- a/tests/integration/components/mapbox-gl-marker-test.js
+++ b/tests/integration/components/mapbox-gl-marker-test.js
@@ -3,12 +3,17 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import MapboxLoader from 'ember-mapbox-gl/-private/mapbox-loader';
 
 module('Integration | Component | mapbox gl marker', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function() {
     this.map = new Map({ container: document.createElement('div') });
+  });
+
+  hooks.beforeEach(function() {
+    return MapboxLoader.load(this.owner.resolveRegistration('config:environment')['mapbox-gl']);
   });
 
   hooks.after(function() {

--- a/tests/integration/components/mapbox-gl-popup-test.js
+++ b/tests/integration/components/mapbox-gl-popup-test.js
@@ -3,12 +3,17 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import MapboxLoader from 'ember-mapbox-gl/-private/mapbox-loader';
 
 module('Integration | Component | mapbox gl popup', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(function() {
     this.map = new Map({ container: document.createElement('div') });
+  });
+
+  hooks.beforeEach(function() {
+    return MapboxLoader.load(this.owner.resolveRegistration('config:environment')['mapbox-gl']);
   });
 
   hooks.after(function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,7 +213,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.2", "@babel/parser@^7.1.6", "@babel/parser@^7.2.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6", "@babel/parser@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
   integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
@@ -567,7 +567,7 @@
     "@babel/parser" "^7.1.2"
     "@babel/types" "^7.1.2"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c"
   integrity sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
@@ -1405,6 +1405,18 @@ babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -5266,6 +5278,14 @@ eslint-plugin-node@^8.0.0:
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
@allthesignals @danidr here is what I am thinking for https://github.com/kturney/ember-mapbox-gl/issues/63

What this does is add 2 private loaders, 1 for dynamic loading and 1 for static loading.
At build time, based on the presence of a `lazyLoad: true` option, only one of the loaders is included in the build to be used at runtime.
Then the `mapbox-gl` component uses the loader to make sure the mapbox-gl-js lib is present before rendering anything.
`mapbox-gl-marker` and `mapbox-gl-popup` both assume that `mapbox-gl` already completed the library load.

Does that seem reasonable or crazy?