### PR TITLE
Remove toLowerCase for event strings

### DIFF
--- a/addon/components/mapbox-gl-on.js
+++ b/addon/components/mapbox-gl-on.js
@@ -49,7 +49,7 @@ const MapboxGlOnComponent = Component.extend({
     const event = get(this, 'event');
     assert(`mapbox-gl-event requires event to be a string, was ${event}`, typeof event === 'string');
 
-    return event.toLowerCase();
+    return event;
   }),
 
   _layerId: computed('layerId', '_action', function () {


### PR DESCRIPTION
Hi! Is there a reason why we make event strings all lower case? I get that mapbox-gl-js events all happen to be lower case, but it'd be nice if this component were even more hands off!

Really, my motivation is that I'm creating bindings for CartoVL, and some of their events are camel-case: https://carto.com/developers/carto-vl/reference/#cartointeractivity, it is a mapbox-gl-js extension.

I'm able to re-use most of ember-mapbox-gl for these bindings, including `mapbox-gl-on` (by passing on-able instances to `eventSource`), but the conversion to lower case is blocking this particular use-case.

Let me know your thoughts! Doesn't seem to be a test for this...
