### PR TITLE
Remove toLowerCase for event strings; update tests

### DIFF
--- a/addon/components/mapbox-gl-on.js
+++ b/addon/components/mapbox-gl-on.js
@@ -49,7 +49,7 @@ const MapboxGlOnComponent = Component.extend({
     const event = get(this, 'event');
     assert(`mapbox-gl-event requires event to be a string, was ${event}`, typeof event === 'string');
 
-    return event.toLowerCase();
+    return event;
   }),
 
   _layerId: computed('layerId', '_action', function () {

--- a/tests/integration/components/mapbox-gl-on-test.js
+++ b/tests/integration/components/mapbox-gl-on-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | mapbox gl on', function(hooks) {
 
     this.set('eventSource', {
       on(eventName, cb) {
-        assert.equal(eventName, 'onzoom', 'subscribes to lowercased event name');
+        assert.equal(eventName, 'onzoom', 'subscribes to event name');
 
         run.next(cb, event);
       },
@@ -32,7 +32,7 @@ module('Integration | Component | mapbox gl on', function(hooks) {
       done();
     };
 
-    await render(hbs`{{mapbox-gl-on eventSource=eventSource event='onZoom' action=(action 'onEvent')}}`);
+    await render(hbs`{{mapbox-gl-on eventSource=eventSource event='onzoom' action=(action 'onEvent')}}`);
   });
 
   test('it works with positionalParams', async function(assert) {
@@ -43,13 +43,13 @@ module('Integration | Component | mapbox gl on', function(hooks) {
 
     this.set('eventSource', {
       on(eventName, cb) {
-        assert.equal(eventName, 'onzoom', 'subscribes to lowercased event name');
+        assert.equal(eventName, 'onzoom', 'subscribes to event name');
 
         run.next(cb, event);
       },
 
       off(eventName) {
-        assert.equal(eventName, 'onzoom', 'unsubscribes to lowercased event name');
+        assert.equal(eventName, 'onzoom', 'unsubscribes to event name');
       }
     });
 
@@ -58,7 +58,7 @@ module('Integration | Component | mapbox gl on', function(hooks) {
       done();
     };
 
-    await render(hbs`{{mapbox-gl-on 'onZoom' (action 'onEvent') eventSource=eventSource}}`);
+    await render(hbs`{{mapbox-gl-on 'onzoom' (action 'onEvent') eventSource=eventSource}}`);
   });
 
   test('it takes a layerId to target', async function(assert) {
@@ -69,14 +69,14 @@ module('Integration | Component | mapbox gl on', function(hooks) {
 
     this.set('eventSource', {
       on(eventName, source, cb) {
-        assert.equal(eventName, 'onzoom', 'subscribes to lowercased event name');
+        assert.equal(eventName, 'onzoom', 'subscribes to event name');
         assert.equal(source, 'layer1', 'passes on layer');
 
         run.next(cb, event);
       },
 
       off(eventName, source) {
-        assert.equal(eventName, 'onzoom', 'unsubscribes to lowercased event name');
+        assert.equal(eventName, 'onzoom', 'unsubscribes to event name');
         assert.equal(source, 'layer1', 'passes on layer');
       }
     });
@@ -86,6 +86,6 @@ module('Integration | Component | mapbox gl on', function(hooks) {
       done();
     };
 
-    await render(hbs`{{mapbox-gl-on 'onZoom' 'layer1' (action 'onEvent') eventSource=eventSource}}`);
+    await render(hbs`{{mapbox-gl-on 'onzoom' 'layer1' (action 'onEvent') eventSource=eventSource}}`);
   });
 });


### PR DESCRIPTION
I wanted to rename the branch but that means "delete branch" to Github.

Original text:
>Hi! Is there a reason why we make event strings all lower case? I get that mapbox-gl-js events all happen to be lower case, but it'd be nice if this component were even more hands off!
> 
> Really, my motivation is that I'm creating bindings for CartoVL, and some of their events are camel-case: https://carto.com/developers/carto-vl/reference/#cartointeractivity, it is a mapbox-gl-js extension.
> 
> I'm able to re-use most of ember-mapbox-gl for these bindings, including mapbox-gl-on (by passing on-able instances to eventSource), but the conversion to lower case is blocking this particular use-case.
> 
> Let me know your thoughts! Doesn't seem to be a test for this...

Original PR: https://github.com/kturney/ember-mapbox-gl/pull/78