### PR TITLE
Test case popup rerender after close

### DIFF
--- a/addon/components/mapbox-gl-popup.js
+++ b/addon/components/mapbox-gl-popup.js
@@ -86,7 +86,13 @@ export default Component.extend({
     const lngLat = this.lngLat;
 
     if (lngLat) {
-      this.popup.setLngLat(lngLat);
+      if (this.popup.isOpen()) {
+        this.popup.setLngLat(lngLat);
+      } else {
+        this.popup.remove();
+        this.popup.addTo(this.map);
+        this.popup.setLngLat(lngLat);
+      }
     }
   },
 

--- a/tests/integration/components/mapbox-gl-popup-test.js
+++ b/tests/integration/components/mapbox-gl-popup-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMap from '../../helpers/create-map';
 
@@ -29,5 +29,23 @@ module('Integration | Component | mapbox gl popup', function (hooks) {
     this.map.fire('click');
 
     assert.verifySteps(['onClose']);
+  });
+
+  test('it handles re-renders on map clicks after closing', async function (assert) {
+    assert.expect(1);
+
+    this.set('clicked', { lngLat: { lng: -93.9688, lat: 37.1314 } });
+
+    await render(hbs`
+      {{#mapbox-gl-popup lngLat=(array this.clicked.lngLat.lng this.clicked.lngLat.lat) map=map MapboxGl=MapboxGl}}
+        Hi
+      {{/mapbox-gl-popup}}
+    `);
+
+    await click('.mapboxgl-popup-close-button');
+
+    this.set('clicked', { lngLat: { lng: -30.9688, lat: 36.1314 } });
+
+    assert.dom('.mapboxgl-popup-content').containsText('Hi');
   });
 });


### PR DESCRIPTION
I'm seeing a weird issue with certain usages of popup:

```handlebars
{{#if click.lngLat}}
  <map.popup @lngLat={{click.lngLat}} @onClose={{this.onClose}} as |popup|>
    Hi {{click.lngLat.lng}} {{click.lngLat.lat}}
  </map.popup>
{{/if}}
```

Closing the popup seems to put it in a forever "closed" state. Subsequent updates to bound attributes do not seem to reopen the popup. Using `onClose` to deal with re-adding the popup, which would force it to open again, lead to infinite re-renders.

The code in the PR here is a reproduction of the issue, fix, and a pretty flaky test. The "fix" here is just a rough sketch which gets it to work but I don't think it's the best way...